### PR TITLE
Add Python.NET integration to qvabbytes project

### DIFF
--- a/qvabbytesD1/Program.cs
+++ b/qvabbytesD1/Program.cs
@@ -1,0 +1,17 @@
+using Python.Runtime;
+
+namespace qvabbytesD1;
+
+internal class Program
+{
+    static void Main(string[] args)
+    {
+        PythonEngine.Initialize();
+        using (Py.GIL())
+        {
+            dynamic script = Py.Import("sample");
+            script.main();
+        }
+        PythonEngine.Shutdown();
+    }
+}

--- a/qvabbytesD1/qvabbytesD1.csproj
+++ b/qvabbytesD1/qvabbytesD1.csproj
@@ -1,9 +1,14 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
-
+<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net9.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
   </PropertyGroup>
 
+  <ItemGroup>
+    <PackageReference Include="Python.Runtime" Version="3.0.1" />
+    <Content Include="sample.py">
+      <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
 </Project>

--- a/qvabbytesD1/sample.py
+++ b/qvabbytesD1/sample.py
@@ -1,0 +1,2 @@
+def main():
+    print("Hello from Python via Python.NET")


### PR DESCRIPTION
## Summary
- target qvabbytes project to .NET 8.0 and reference Python.Runtime
- add Program using Python.NET to run a sample Python script
- include sample script and configure it to copy to build output

## Testing
- `dotnet build qvabbytesD1` *(fails: command not found)*
- `apt-get update` *(fails: repository not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68a5895641f483218d7a5d5b796ac618